### PR TITLE
FASTER deletions and reading RocksDB config from file

### DIFF
--- a/state/Cargo.toml
+++ b/state/Cargo.toml
@@ -6,9 +6,13 @@ edition = "2018"
 
 [dependencies]
 bincode = "1.1.2"
-faster-rs = "0.9"
 tempfile = "3"
 
 [dependencies.rocksdb]
 git = "https://github.com/matthewbrookes/rust-rocksdb"
 branch = "master"
+
+[dependencies.faster-rs]
+git = "https://github.com/matthewbrookes/faster-rs"
+branch="deletion-logscan"
+

--- a/state/src/backends/rocksdb/mod.rs
+++ b/state/src/backends/rocksdb/mod.rs
@@ -11,6 +11,11 @@ use rocksdb::{Options, DB};
 use std::hash::Hash;
 use std::rc::Rc;
 use tempfile::TempDir;
+use std::fs::File;
+use std::io::BufRead;
+use std::io::BufReader;
+use std::iter::FromIterator;
+use std::path::Path;
 
 mod managed_count;
 mod managed_map;
@@ -35,19 +40,58 @@ fn merge_numbers(
     Some(bincode::serialize(&result).unwrap())
 }
 
+// read RocksDB configuration from a file
+fn read_rocksdb_config() -> (usize, usize, usize) {
+    let config_path = String::from("rocksdb.config");
+    let file = File::open(config_path).expect("Config file not found or cannot be opened");
+    let content = BufReader::new(&file);
+    let mut blocksize = 0;
+    let mut lrusize = 0;
+    let mut write_buffer_size = 0;
+    for line in content.lines() {
+        let line = line.expect("Could not read the line");
+        let line = line.trim();
+        if line.starts_with("#") || line.starts_with(";") || line.is_empty() {
+            continue;
+        }
+        let tokens = Vec::from_iter(line.split_whitespace());
+        let name = tokens.first().unwrap();
+        let tokens = tokens.get(1..).unwrap();
+        let tokens = tokens.iter().filter(|t| !t.starts_with("="));
+        let tokens = tokens.take_while(|t| !t.starts_with("#") && !t.starts_with(";"));
+        let mut parameters = String::new();
+        tokens.for_each(|t| { parameters.push_str(t); parameters.push(' '); });
+        let parameters = parameters.split(',').map(|s| s.trim());
+        let parameters: Vec<String> = parameters.map(|s| s.to_string()).collect();
+
+        // Setting the config parameters
+        match name.to_lowercase().as_str() {
+            "blocksize" => blocksize = parameters.get(0).unwrap().parse::<usize>().expect("couldn't parse tablesize"),
+            "lrusize" => lrusize = parameters.get(0).unwrap().parse::<usize>().expect("couldn't parse logsize"),
+            "writebuffersize" => write_buffer_size = parameters.get(0).unwrap().parse::<usize>().expect("couldn't parse writebuffersize"),
+            _ => (),
+        }
+    }
+    (blocksize, lrusize, write_buffer_size)
+}
+
 impl StateBackend for RocksDBBackend {
     fn new() -> Self {
-        let directory = TempDir::new_in(".").expect("Unable to create directory for FASTER");
+        let directory = TempDir::new_in(".").expect("Unable to create directory for RocksDB");
         let mut block_based_options = BlockBasedOptions::default();
-        block_based_options.set_block_size(128 * 1024 * 1024); // 128 KB
-        block_based_options.set_lru_cache(256 * 1024 * 1024 * 1024); // 256 MB
+        let (block_size, lru_cache, write_buffer_size) = read_rocksdb_config();
+        println!("Configuring a RocksDB instance with block size {:?}, cache {:?}, and write buffer size {:?}",
+                 block_size, lru_cache, write_buffer_size);
+        block_based_options.set_block_size(block_size);
+        block_based_options.set_lru_cache(lru_cache);
+        block_based_options.set_cache_index_and_filter_blocks(true);
         let mut options = Options::default();
         options.create_if_missing(true);
         options.set_merge_operator("merge_numbers", merge_numbers, Some(merge_numbers));
         options.set_use_fsync(false);
         options.set_min_write_buffer_number(2);
         options.set_max_write_buffer_number(4);
-        options.set_write_buffer_size(3 * 1024 * 1024 * 1024); // 3 GB
+        options.set_write_buffer_size(write_buffer_size);
         options.set_block_based_table_factory(&block_based_options);
         let db = DB::open(&options, directory.into_path()).expect("Unable to instantiate RocksDB");
         RocksDBBackend { db: Rc::new(db) }

--- a/state/src/backends/rocksdbmerge/mod.rs
+++ b/state/src/backends/rocksdbmerge/mod.rs
@@ -27,18 +27,15 @@ fn merge_vectors(
     operands: &mut MergeOperands,
 ) -> Option<Vec<u8>> {
    
-   let mut result: Vec<u8> = Vec::with_capacity(operands.size_hint().0);
-   existing_val.map(|v| {
-       for e in v {
-           result.push(*e)
-       }
-   });
-   for op in operands {
-       for e in op {
-           result.push(*e)
-       }
-   }
-   Some(result)
+   let mut result: Vec<(usize,usize)> = Vec::with_capacity(operands.size_hint().0);
+
+    if let Some(val) = existing_val {
+        result.extend(bincode::deserialize::<Vec<(usize,usize)>>(val).unwrap());
+    }
+    for operand in operands {
+        result.extend(bincode::deserialize::<Vec<(usize,usize)>>(operand).unwrap());
+    }
+    Some(bincode::serialize(&result).unwrap())
 }
 
 impl StateBackend for RocksDBMergeBackend {

--- a/state/src/backends/rocksdbmerge2/mod.rs
+++ b/state/src/backends/rocksdbmerge2/mod.rs
@@ -11,6 +11,11 @@ use rocksdb::{Options, DB};
 use std::hash::Hash;
 use std::rc::Rc;
 use tempfile::TempDir;
+use std::fs::File;
+use std::io::BufRead;
+use std::io::BufReader;
+use std::iter::FromIterator;
+use std::path::Path;
 
 mod managed_count;
 mod managed_map;
@@ -37,19 +42,57 @@ fn merge_count(
     Some(bincode::serialize(&result).unwrap())
 }
 
+// read RocksDB configuration from a file
+fn read_rocksdb_config() -> (usize, usize, usize) {
+    let config_path = String::from("rocksdbmerge2.config");
+    let file = File::open(config_path).expect("Config file not found or cannot be opened");
+    let content = BufReader::new(&file);
+    let mut blocksize = 0;
+    let mut lrusize = 0;
+    let mut write_buffer_size = 0;
+    for line in content.lines() {
+        let line = line.expect("Could not read the line");
+        let line = line.trim();
+        if line.starts_with("#") || line.starts_with(";") || line.is_empty() {
+            continue;
+        }
+        let tokens = Vec::from_iter(line.split_whitespace());
+        let name = tokens.first().unwrap();
+        let tokens = tokens.get(1..).unwrap();
+        let tokens = tokens.iter().filter(|t| !t.starts_with("="));
+        let tokens = tokens.take_while(|t| !t.starts_with("#") && !t.starts_with(";"));
+        let mut parameters = String::new();
+        tokens.for_each(|t| { parameters.push_str(t); parameters.push(' '); });
+        let parameters = parameters.split(',').map(|s| s.trim());
+        let parameters: Vec<String> = parameters.map(|s| s.to_string()).collect();
+
+        // Setting the config parameters
+        match name.to_lowercase().as_str() {
+            "blocksize" => blocksize = parameters.get(0).unwrap().parse::<usize>().expect("couldn't parse tablesize"),
+            "lrusize" => lrusize = parameters.get(0).unwrap().parse::<usize>().expect("couldn't parse logsize"),
+            "writebuffersize" => write_buffer_size = parameters.get(0).unwrap().parse::<usize>().expect("couldn't parse writebuffersize"),
+            _ => (),
+        }
+    }
+    (blocksize, lrusize, write_buffer_size)
+}
+
 impl StateBackend for RocksDBMergeBackend2 {
     fn new() -> Self {
         let directory = TempDir::new_in(".").expect("Unable to create directory for FASTER");
         let mut block_based_options = BlockBasedOptions::default();
-        block_based_options.set_block_size(128 * 1024 * 1024); // 128 KB
-        block_based_options.set_lru_cache(256 * 1024 * 1024 * 1024); // 256 MB
+        let (block_size, lru_cache, write_buffer_size) = read_rocksdb_config();
+        println!("Configuring a RocksDB instance with block size {:?}, cache {:?}, and write buffer size {:?}",
+                 block_size, lru_cache, write_buffer_size);
+        block_based_options.set_block_size(block_size);
+        block_based_options.set_lru_cache(lru_cache);
         let mut options = Options::default();
         options.create_if_missing(true);
         options.set_merge_operator("merge_count", merge_count, Some(merge_count));
         options.set_use_fsync(false);
         options.set_min_write_buffer_number(2);
         options.set_max_write_buffer_number(4);
-        options.set_write_buffer_size(3 * 1024 * 1024 * 1024); // 3 GB
+        options.set_write_buffer_size(write_buffer_size);
         options.set_block_based_table_factory(&block_based_options);
         let db = DB::open(&options, directory.into_path()).expect("Unable to instantiate RocksDBMerge");
         RocksDBMergeBackend2 { db: Rc::new(db) }

--- a/timely/Cargo.toml
+++ b/timely/Cargo.toml
@@ -23,7 +23,7 @@ serde = "1.0"
 serde_derive = "1.0"
 abomonation = "0.7"
 abomonation_derive = "0.3"
-faster-rs = "0.9"
+#faster-rs = { git = "https://github.com/matthewbrookes/faster-rs.git", branch="deletion-logscan" }
 tempfile = "3"
 timely_bytes = { path = "../bytes", version = "0.9" }
 timely_logging = { path = "../logging", version = "0.9" }
@@ -33,3 +33,7 @@ timely_state = { path = "../state", version = "0.1.0" }
 [dev-dependencies]
 timely_sort="0.1.6"
 rand="0.4"
+
+[dependencies.faster-rs]
+git = "https://github.com/matthewbrookes/faster-rs"
+branch="deletion-logscan"


### PR DESCRIPTION
- Update `faster-rs` dependency to `https://github.com/matthewbrookes/faster-rs/tree/deletion-logscan` so we can use deletions.
- Deserialize when merging vectors in `RocksDBMergeBackend`.
- Read config options for all RocksDB backends from files.